### PR TITLE
Hide related projects section when empty

### DIFF
--- a/src/components/DTCC1ProjectsDetail.vue
+++ b/src/components/DTCC1ProjectsDetail.vue
@@ -70,7 +70,7 @@
     </section>
 
     <!-- Related projects -->
-    <section class="section gradient-sunrise related">
+    <section v-if="related.length" class="section gradient-sunrise related">
       <div class="container">
         <h3 class="h3-30 section-title">Related DTCC1 projects</h3>
         <div class="cards">

--- a/src/components/ProjectsDetail.vue
+++ b/src/components/ProjectsDetail.vue
@@ -70,7 +70,7 @@
     </section>
 
     <!-- Related projects -->
-    <section class="section gradient-sunrise related">
+    <section v-if="related.length" class="section gradient-sunrise related">
       <div class="container">
         <h3 class="h3-30 section-title">Related projects</h3>
         <div class="cards">


### PR DESCRIPTION
## Summary
- add guards to the related project sections so they render only when data is present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690b50f13490832099a76bbf2ce84759